### PR TITLE
Add mobile viewport meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Générateur d'Appréciations Professionnelles</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p/1yxr7XK6T5+u3DkXJn2RoaXzlb+X2JpHfS2KfV/luzV9Y1UkXGmE1ps9G0K5g1QMf1BkXx5cC+PQX+U3qFHQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
## Summary
- rename `indexv2.html` to `index.html`
- enable responsive scaling by adding `<meta name="viewport" content="width=device-width, initial-scale=1.0">`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --yes playwright --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `curl -A "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1" file:///workspace/appreciations/index.html | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68bd6e7240148326beb3ec0e804a5e71