### PR TITLE
Add 1AA roster entries

### DIFF
--- a/data/eleves.json
+++ b/data/eleves.json
@@ -232,5 +232,95 @@
     "nom": "",
     "classe": "1AA",
     "groupe": 1
+  },
+  {
+    "prenom": "AJENGUI",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "BORIN",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "CHACHUAT-BRENAS",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "DAOUDA",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "FALL SEYE",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "JIMENEZ TABORDA",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "KORDZADZE",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "MALUNDA",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "NDIAYE",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "RIGOUSTE",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "ROCHE",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "TALON",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "TAZABAEV",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "WADE",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
+  },
+  {
+    "prenom": "ZINGILA",
+    "nom": "",
+    "classe": "1AA",
+    "groupe": 2
   }
 ]


### PR DESCRIPTION
## Summary
- add additional 1AA students from the provided roster into the dataset
- place the new students in group 2 to keep them grouped together

## Testing
- python -m json.tool data/eleves.json >/dev/null


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec83aa4f48326a46f3fda835b7139)